### PR TITLE
Makes Vector_Size and Vector_Cap not inline

### DIFF
--- a/rmutil/vector.c
+++ b/rmutil/vector.c
@@ -55,6 +55,13 @@ int Vector_Resize(Vector *v, size_t newcap) {
     return v->cap;
 }
 
+int Vector_Size(Vector *v) {
+    return v->top;
+}
+
+int Vector_Cap(Vector *v) {
+    return v->cap;
+}
 
 Vector *__newVectorSize(size_t elemSize, size_t cap) {
     

--- a/rmutil/vector.c
+++ b/rmutil/vector.c
@@ -55,11 +55,11 @@ int Vector_Resize(Vector *v, size_t newcap) {
     return v->cap;
 }
 
-int Vector_Size(Vector *v) {
+inline int Vector_Size(Vector *v) {
     return v->top;
 }
 
-int Vector_Cap(Vector *v) {
+inline int Vector_Cap(Vector *v) {
     return v->cap;
 }
 

--- a/rmutil/vector.h
+++ b/rmutil/vector.h
@@ -56,10 +56,10 @@ int __vector_PushPtr(Vector *v, void *elem);
 int Vector_Resize(Vector *v, size_t newcap);
 
 /* return the used size of the vector, regardless of capacity */
-inline int Vector_Size(Vector *v) { return v->top; }
+int Vector_Size(Vector *v);
 
 /* return the actual capacity */
-inline int Vector_Cap(Vector *v) { return v->cap; }
+int Vector_Cap(Vector *v);
 
 /* free the vector and the underlying data. Does not release its elements if
  * they are pointers*/


### PR DESCRIPTION
Otherwise, when turning off -03, Redis complains about not being
able to find the symbols for them.