### PR TITLE
Fix Vector to maintain the correct size

### DIFF
--- a/rmutil/vector.c
+++ b/rmutil/vector.c
@@ -6,7 +6,7 @@ inline int __vector_PushPtr(Vector *v, void *elem) {
     Vector_Resize(v, v->cap ? v->cap * 2 : 1);
   }
 
-  __vector_PutPtr(v, v->top++, elem);
+  __vector_PutPtr(v, v->top, elem);
   return v->top;
 }
 
@@ -43,9 +43,9 @@ inline int __vector_PutPtr(Vector *v, size_t pos, void *elem) {
   } else {
     memset(v->data + pos * v->elemSize, 0, v->elemSize);
   }
-  // move the end offset to pos if we grew
-  if (pos > v->top) {
-    v->top = pos;
+  // move the end offset to pos + 1 if we grew
+  if (pos >= v->top) {
+    v->top = pos + 1;
   }
   return 1;
 }


### PR DESCRIPTION
The `Vector_Put` function does not correctly maintain `v->top` and thus its size.

For example, `v1` and `v2` should both have size `1` in the next code. However, `v1` and `v2` have size `0` and `1`, respectively, hereafter:
```c
int x = 1;
Vector *v1 = NewVector(int, 0);
Vector *v2 = NewVector(int, 0);
Vector_Put(v1, 0, &x);
Vector_Push(v2, &x);
```


This PR makes `v->top` point at the next to the last element at any time after modification.