### PR TITLE
Support optional modes

### DIFF
--- a/example/module.c
+++ b/example/module.c
@@ -137,7 +137,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx) {
   }
 
   // register example.hgetset - using the shortened utility registration macro
-  RMUtil_RegisterWriteCmd(ctx, "example.hgetset", HGetSetCommand);
+  RMUtil_RegisterWriteCmd(ctx, "example.hgetset", HGetSetCommand, "fast");
 
   // register the unit test
   RMUtil_RegisterWriteCmd(ctx, "example.test", TestModule);

--- a/rmutil/util.h
+++ b/rmutil/util.h
@@ -13,13 +13,15 @@
         return REDISMODULE_ERR; \
     }
 
-
-#define __rmutil_register_cmd(ctx, cmd, f, mode) if (RedisModule_CreateCommand(ctx, cmd, f, mode, \
-                                                  1, 1, 1) == REDISMODULE_ERR) return REDISMODULE_ERR;
+#define __rmutil_register_cmd(ctx, cmd, f, mode) \
+    if (RedisModule_CreateCommand(ctx, cmd, f, \
+        (!strcmp(mode, "readonly ")) ? "readonly" : \
+        (!strcmp(mode, "write ")) ? "write" : mode, \
+        1, 1, 1) == REDISMODULE_ERR) return REDISMODULE_ERR;
                                                   
-#define RMUtil_RegisterReadCmd(ctx, cmd, f) __rmutil_register_cmd(ctx, cmd, f, "readonly")
+#define RMUtil_RegisterReadCmd(ctx, cmd, f, ...) __rmutil_register_cmd(ctx, cmd, f, "readonly " __VA_ARGS__)
 
-#define RMUtil_RegisterWriteCmd(ctx, cmd, f) __rmutil_register_cmd(ctx, cmd, f, "write")                                          
+#define RMUtil_RegisterWriteCmd(ctx, cmd, f, ...) __rmutil_register_cmd(ctx, cmd, f, "write " __VA_ARGS__)
 
 /* RedisModule utilities. */
 


### PR DESCRIPTION
This PR allows `RMUtil_RegisterReadCmd` and `RMUtil_RegisterWriteCmd` to receive optional modes as a C string without breaking the backward compatibility.

The mode of commands created via them is currently fixed to `readonly` or `write`. This can be often inconvenient and restrict the use of them.

