### PR TITLE
Warn if gcc version is lower than 4.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,15 @@
+# Warn if gcc version is lower than 4.8 (-Og was introduced in this version)
+
+MIN_GCC_VERSION = "4.8"
+GCC_VERSION := "`gcc -dumpversion`"
+IS_GCC_ABOVE_MIN_VERSION := $(shell expr "$(GCC_VERSION)" ">=" "$(MIN_GCC_VERSION)")
+ifeq "$(IS_GCC_ABOVE_MIN_VERSION)" "1"
+	GCC_VERSION_STRING := "GCC version OK $(GCC_VERSION) >= $(MIN_GCC_VERSION)"
+else
+	GCC_VERSION_STRING := "ERROR: gcc version $(GCC_VERSION) is lower than $(MIN_GCC_VERSION), 'gcc -Og' might fail."
+endif
+
+
 #set environment variable RM_INCLUDE_DIR to the location of redismodule.h
 ifndef RM_INCLUDE_DIR
 	RM_INCLUDE_DIR=./
@@ -15,6 +27,7 @@ endif
 all: module.so
 
 module.so:
+	@echo $(GCC_VERSION_STRING)
 	$(MAKE) -C ./$(SRC_DIR)
 	cp ./$(SRC_DIR)/module.so .
 


### PR DESCRIPTION
The `-Og` parameter was introduced in in gcc 4.8. When running `make` with older versions of gcc (as the default one in OSX/XCode), the following error message appears:

    error: invalid integral value 'g' in '-Og'

The following PR shows an error message if the gcc version is older than 4.8. I've chosen not to exit the make process, just in case this logic would fail in some edge case.

See also: 
* [Makefile: Emit warning gcc version is lower than 4.8.0](http://stackoverflow.com/questions/42419301/makefile-emit-warning-gcc-version-is-lower-than-4-8-0/42425596#42425596)
* [GCC 4.8 Release Series Changes, New Features, and Fixes](https://gcc.gnu.org/gcc-4.8/changes.html)