### PR TITLE
util.h: added missing include for string.h

### DIFF
--- a/rmutil/util.h
+++ b/rmutil/util.h
@@ -3,6 +3,7 @@
 
 #include <redismodule.h>
 #include <stdarg.h>
+#include <string.h>
 
 /// make sure the response is not NULL or an error, and if it is sends the error to the client and exit the current function
 #define  RMUTIL_ASSERT_NOERROR(r) \


### PR DESCRIPTION
The usage of `strcmp` function requires the inclusion of string.h