### PR TITLE
API.md: typo fix

### DIFF
--- a/API.md
+++ b/API.md
@@ -221,7 +221,7 @@ is a function to do this:
 Similarly in order to parse a string as a number:
 
     long long myval;
-    if (RedisModule_StringToLongLong(ctx,argv[1],&myval) == REDISMODULE_OK) {
+    if (RedisModule_StringToLongLong(argv[1],&myval) == REDISMODULE_OK) {
         /* Do something with 'myval' */
     }
 


### PR DESCRIPTION
The `RedisModule_StringToLongLong` declaration is as the following:
`int REDISMODULE_API_FUNC(RedisModule_StringToLongLong)(const RedisModuleString *str, long long *ll);
`