### PR TITLE
Fix RMUtil_RegisterReadCmd macro

### DIFF
--- a/rmutil/util.h
+++ b/rmutil/util.h
@@ -18,9 +18,7 @@
   if (RedisModule_CreateCommand(ctx, cmd, f, mode, 1, 1, 1) == REDISMODULE_ERR) \
     return REDISMODULE_ERR;
 
-#define RMUtil_RegisterReadCmd(ctx, cmd, f)      \
-  __rmutil_register_cmd(ctx, cmd, f, "readonly") \
-  }
+#define RMUtil_RegisterReadCmd(ctx, cmd, f) __rmutil_register_cmd(ctx, cmd, f, "readonly")
 
 #define RMUtil_RegisterWriteCmd(ctx, cmd, f) __rmutil_register_cmd(ctx, cmd, f, "write")
 


### PR DESCRIPTION
Looks like this guy was missed [introduced?](https://github.com/RedisLabs/RedisModulesSDK/commit/42df4c3503e2bb6f23f7f7f6a20bb358bc3ac419#diff-6a7d0b320897610bf68253714b12d449R21) when utils.h got a makeover.