### PR TITLE
Replacing the void * cast to the real type cast 

### DIFF
--- a/rmutil/sds.h
+++ b/rmutil/sds.h
@@ -79,7 +79,7 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_TYPE_64 4
 #define SDS_TYPE_MASK 7
 #define SDS_TYPE_BITS 3
-#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (struct sdshdr##T*)((s)-(sizeof(struct sdshdr##T)));
 #define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
 


### PR DESCRIPTION
Replacing the void * cast to the real type cast to avoid compilation error on MacOSX.

On MacOSX this error is raised by the clang compiler:
`rmutil/sds.h:110:13: error: cannot initialize a variable of type 'struct sdshdr8 *' with an rvalue of type 'void *'
            SDS_HDR_VAR(8,s);`