### PR TITLE
correct typo in BLOCK.md

### DIFF
--- a/BLOCK.md
+++ b/BLOCK.md
@@ -220,7 +220,7 @@ reply and timeout callback:
         if (RedisModule_IsBlockedReplyRequest(ctx)) {
             long *mynumber = RedisModule_GetBlockedClientPrivateData(ctx);
             return RedisModule_ReplyWithLongLong(ctx,mynumber);
-        } else if (RedisModule_IsBlockedTimeoutRequest) {
+        } else if (RedisModule_IsBlockedTimeoutRequest(ctx)) {
             return RedisModule_ReplyWithNull(ctx);
         }
 


### PR DESCRIPTION
small typo correction in BLOCK.md where `RedisModule_IsBlockedTimeoutRequest` needs to be called like a function (with `ctx` as argument) inside the if test.