### PR TITLE
MOD-14124 - add getUserUserName api

### DIFF
--- a/redismodule.h
+++ b/redismodule.h
@@ -1380,6 +1380,7 @@ REDISMODULE_API RedisModuleUser * (*RedisModule_CreateModuleUser)(const char *na
 REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextUser)(RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleUser * (*RedisModule_GetContextUser)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_GetUserUsername)(const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const char* acl) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACLString)(RedisModuleCtx * ctx, RedisModuleUser *user, const char* acl, RedisModuleString **error) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetModuleUserACLString)(RedisModuleUser *user) REDISMODULE_ATTR;
@@ -1780,6 +1781,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(FreeModuleUser);
     REDISMODULE_GET_API(SetContextUser);
     REDISMODULE_GET_API(GetContextUser);
+    REDISMODULE_GET_API(GetUserUsername);
     REDISMODULE_GET_API(SetModuleUserACL);
     REDISMODULE_GET_API(SetModuleUserACLString);
     REDISMODULE_GET_API(GetModuleUserACLString);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new exported module API symbol and wires it into `RedisModule_Init`, which can affect module ABI/API compatibility if server-side support or version-gating is missing.
> 
> **Overview**
> Adds a new Modules API function pointer, `RedisModule_GetUserUsername(const RedisModuleUser *user)`, allowing modules to obtain a username from a `RedisModuleUser`.
> 
> Updates the `RedisModule_Init` API lookup table (`REDISMODULE_GET_API(GetUserUsername)`) so the new symbol is resolved at module load time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e33fa74e3689b302f0137eb721942f5b2365c6a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->