### PR TITLE
MOD-15262- update the GetUserUserName api according to redis

### DIFF
--- a/redismodule.h
+++ b/redismodule.h
@@ -1380,7 +1380,7 @@ REDISMODULE_API RedisModuleUser * (*RedisModule_CreateModuleUser)(const char *na
 REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextUser)(RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleUser * (*RedisModule_GetContextUser)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetUserUsername)(const RedisModuleUser *user) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_GetUserUsername)(RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const char* acl) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACLString)(RedisModuleCtx * ctx, RedisModuleUser *user, const char* acl, RedisModuleString **error) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetModuleUserACLString)(RedisModuleUser *user) REDISMODULE_ATTR;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public module API signature for `RedisModule_GetUserUsername`, which is a compile-time breaking change for any modules calling it. Risk is limited to API compatibility/build failures rather than runtime behavior.
> 
> **Overview**
> Updates the Redis Modules header to match upstream Redis by changing `RedisModule_GetUserUsername` to take a `RedisModuleCtx *ctx` parameter in addition to the `RedisModuleUser *user` argument.
> 
> This is an **API signature change** that requires updating any module code that calls `RedisModule_GetUserUsername` to pass a context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a9e90b678df7e7a961bfabe3cea1546faf7d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->