### PR TITLE
Add RLEC cluster node slot ranges API

### DIFF
--- a/redismodule-rlec.h
+++ b/redismodule-rlec.h
@@ -48,6 +48,7 @@ REDISMODULE_API int (*RedisModule_SetSwapKeyMetadata)(RedisModuleCtx *ctx, Redis
 REDISMODULE_API int (*RedisModule_IsKeyInRam)(RedisModuleCtx *ctx, RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_EnablePostponeClients)(void) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DisablePostponeClients)(void) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleSlotRangeArray *(*RedisModule_GetClusterNodeSlotRanges)(RedisModuleCtx *ctx, const char *nodeid) REDISMODULE_ATTR;
 
 /* Flags */
 
@@ -98,6 +99,7 @@ REDISMODULE_API void (*RedisModule_ShardingGetSlotRange)(int *first_slot, int *l
     REDISMODULE_GET_API(IsKeyInRam); \
     REDISMODULE_GET_API(EnablePostponeClients); \
     REDISMODULE_GET_API(DisablePostponeClients); \
+    REDISMODULE_GET_API(GetClusterNodeSlotRanges); \
     /**/
 
 //---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add the RLEC-only `RedisModule_GetClusterNodeSlotRanges` module API declaration and loader entry.

## Details

- Declares `RedisModule_GetClusterNodeSlotRanges` in `redismodule-rlec.h`.
- Adds `REDISMODULE_GET_API(GetClusterNodeSlotRanges)` to `REDISMODULE_RLEC_API_DEFS` so RLEC builds load the API during `RedisModule_Init`.
- Leaves generic `redismodule.h` unchanged because this API is only expected in Enterprise/RLEC for the target RediSearch backports.

## Verification

Header-only SDK change. Downstream RediSearch backport branches will be rebuilt and tested after bumping this submodule commit.